### PR TITLE
CreateResource: convert data hash to HashWithIndifferentAccess

### DIFF
--- a/lib/acfs/model/query_methods.rb
+++ b/lib/acfs/model/query_methods.rb
@@ -117,6 +117,7 @@ module Acfs::Model
       end
 
       def create_resource(data, opts = {})
+        data = data.with_indifferent_access
         type = data.delete 'type'
         klass = resource_class_lookup(type)
         (opts[:origin].is_a?(klass) ? opts[:origin] : klass.new).tap do |m|


### PR DESCRIPTION
In Rails test environment, hashs are – in contrast to development env or
also the Acfs test environment– not automagically converted to strings. This
breakes the RTI check for the 'type'-attribute, since this is expected to be
a string.

For avoiding future errors while creating the resource, the data hash now gets
parsed as a ActiveSupport::HashWithIndifferentAccess, which can be accessed by
either stings or symbols as key.
