### PR TITLE
[RTI] Fix: rescue invalid type field errors

### DIFF
--- a/lib/acfs/errors.rb
+++ b/lib/acfs/errors.rb
@@ -96,7 +96,7 @@ module Acfs
     def initialize(opts = {})
       @base_class    = opts.delete :base_class
       @type_name     = opts.delete :type_name
-      opts[:message] = "Recieved ressource type #{type_name} is no subclass of #{base_class}"
+      opts[:message] = "Recieved ressource type `#{type_name}` is no subclass of #{base_class}"
       super
     end
   end

--- a/lib/acfs/model/query_methods.rb
+++ b/lib/acfs/model/query_methods.rb
@@ -179,6 +179,8 @@ module Acfs::Model
         klass = type.camelize.constantize
         raise Acfs::ResourceTypeError.new type_name: type, base_class: self unless klass <= self
         klass
+      rescue NameError, NoMethodError
+        raise Acfs::ResourceTypeError.new type_name: type, base_class: self
       end
 
     end

--- a/spec/acfs/model/query_methods_spec.rb
+++ b/spec/acfs/model/query_methods_spec.rb
@@ -151,13 +151,32 @@ describe Acfs::Model::QueryMethods do
       end
 
       context 'with invalid type set' do
-        before do
-          stub_request(:get, 'http://computers.example.org/computers').to_return response([{ id: 1, type: 'MyUser' }, { id: 2, type: 'Computer' }, { id: 3, type: 'Mac' }])
+        shared_examples 'with invalid type' do
+          it 'should raise error if type is no subclass' do
+            Computer.all
+            expect { Acfs.run }.to raise_error(Acfs::ResourceTypeError)
+          end
         end
 
-        it 'should raise error if type is no subclass' do
-          Computer.all
-          expect { Acfs.run }.to raise_error(Acfs::ResourceTypeError)
+        context 'with another resource as type instead' do
+          before do
+            stub_request(:get, 'http://computers.example.org/computers').to_return response([{ id: 1, type: 'MyUser' }, { id: 2, type: 'Computer' }, { id: 3, type: 'Mac' }])
+          end
+          it_behaves_like 'with invalid type'
+        end
+
+        context 'with a random string as type instead' do
+          before do
+            stub_request(:get, 'http://computers.example.org/computers').to_return response([{ id: 1, type: 'PC' }, { id: 2, type: 'noValidType' }, { id: 3, type: 'Mac' }])
+          end
+          it_behaves_like 'with invalid type'
+        end
+
+        context 'with a non-string as type instead' do
+          before do
+            stub_request(:get, 'http://computers.example.org/computers').to_return response([{ id: 1, type: 'PC' }, { id: 2, type: 'Computer' }, { id: 3, type: 42 }])
+          end
+          it_behaves_like 'with invalid type'
         end
       end
     end


### PR DESCRIPTION
When a `type` field is set in an Acfs-Resource, Acfs mimics Rails' STI by trying to instantiate a resource with the name of `type.camelize.constantize`. This fails, if the type string does not represent a valid subclass of the resource.

For better traceability, a `ResourceTypeError` indicating the type mismatch gets raised.
