### PR TITLE
Add simple dict attribute type

### DIFF
--- a/lib/acfs/model/attributes/dict.rb
+++ b/lib/acfs/model/attributes/dict.rb
@@ -21,7 +21,8 @@ module Acfs::Model::Attributes
     # @raise [TypeError] If object cannot be casted to a hash.
     #
     def cast_type(obj)
-      return obj.to_h if obj.respond_to? :to_a
+      return obj if obj.is_a? Hash
+      return obj.to_h if obj.respond_to? :to_h
       raise TypeError.new "Cannot cast #{obj.inspect} to hash."
     end
   end

--- a/spec/acfs/model/attributes/dict_spec.rb
+++ b/spec/acfs/model/attributes/dict_spec.rb
@@ -24,10 +24,26 @@ describe Acfs::Model::Attributes::Dict do
     end
 
     context 'with hashable object' do
-      let(:sample) { [[3, 4], ['test', true]] }
+      let(:sample) do
+        o = Object.new
+        class << o
+          def to_h
+            {3 => 4, 'test' => true}
+          end
+        end
+        o
+      end
 
       it 'should cast object to hash' do
         expect(subject.cast(sample)).to eq 3 => 4, 'test' => true
+      end
+    end
+
+    context 'with hash subclass' do
+      let(:sample) { HashWithIndifferentAccess.new :test => :foo, 34 => 12 }
+
+      it 'should return obj unmodified' do
+        expect(subject.cast(sample)).to be sample
       end
     end
   end


### PR DESCRIPTION
To support simple nested resource responses, allow returning dict/hash
as values. Like list there is no further checking of dict key or value
types.
