### PR TITLE
Add optional attributes

### DIFF
--- a/lib/acfs/model/attributes.rb
+++ b/lib/acfs/model/attributes.rb
@@ -23,6 +23,8 @@ module Acfs::Model
     #
     # Write default attributes defined in resource class.
     #
+    # Optional attributes will not be initialized.
+    #
     # @see #write_attributes
     # @see ClassMethods#attributes
     #
@@ -35,6 +37,8 @@ module Acfs::Model
     # @api public
     #
     # Returns ActiveModel compatible list of attributes and values.
+    #
+    # Will not include not set optional attributes.
     #
     # @example
     #   class User
@@ -180,11 +184,15 @@ module Acfs::Model
       #
       # Available types can be found in `Acfs::Model::Attributes::*`.
       #
+      # Optional attributes will not be included in most attribute listing
+      # unless they are populated from server or client.
+      #
       # @example
       #   class User
       #     include Acfs::Model
       #     attribute :name, :string, default: 'Anon'
       #     attribute :email, :string, default: lambda{ "#{name}@example.org"}
+      #     attribute :profile, :string, optional: true
       #   end
       #
       # @param [ #to_sym ] name Attribute name.
@@ -202,6 +210,8 @@ module Acfs::Model
       #
       # Return list of possible attributes and default values for this model class.
       #
+      # This method will not include attributes marked as optional.
+      #
       # @example
       #   class User
       #     include Acfs::Model
@@ -215,7 +225,7 @@ module Acfs::Model
       def attributes
         Hash.new.tap do |attrs|
           defined_attributes.each do |key, attr|
-            attrs[key] = attr.default_value
+            attrs[key] = attr.default_value unless attr.optional?
           end
         end
       end

--- a/lib/acfs/model/attributes/base.rb
+++ b/lib/acfs/model/attributes/base.rb
@@ -6,6 +6,10 @@ module Acfs::Model::Attributes
     def initialize(opts = {})
       @options = opts
       @options.reverse_merge! allow_nil: true
+
+      if options.key?(:default) && optional?
+        raise ArgumentError.new 'Optional attributes cannot have a default value.'
+      end
     end
 
     def nil_allowed?
@@ -18,6 +22,10 @@ module Acfs::Model::Attributes
 
     def default_value
       options[:default].is_a?(Proc) ? options[:default] : cast(options[:default])
+    end
+
+    def optional?
+      options.fetch(:optional, false)
     end
 
     def cast(obj)

--- a/spec/acfs/model/attributes_spec.rb
+++ b/spec/acfs/model/attributes_spec.rb
@@ -24,6 +24,17 @@ describe Acfs::Model::Attributes do
         expect(model.new.mail).to be == 'John@srv.tld'
       end
     end
+
+    context 'with optional attribute' do
+      before do
+        model.attribute :name, :string, default: 'John'
+        model.attribute :profile, :string, optional: true
+      end
+
+      it 'should not be included in attributes' do
+        expect(model.new.attributes.keys).to match_array %w(name)
+      end
+    end
   end
 
   describe '#attributes' do
@@ -34,6 +45,18 @@ describe Acfs::Model::Attributes do
 
     it 'should return hash of all attributes' do
       expect(model.new.attributes).to be == { name: 'John', age: 25 }.stringify_keys
+    end
+
+    context 'optional attribute' do
+      before { model.attribute :profile, :string, optional: true }
+
+      it 'should not be include if not set' do
+        expect(model.new.attributes.keys).to_not include 'profile'
+      end
+
+      it 'should be include if set' do
+        expect(model.new.tap{|m| m.profile = 'abc'}.attributes).to include 'profile' => 'abc'
+      end
     end
   end
 
@@ -97,6 +120,15 @@ describe Acfs::Model::Attributes do
     it 'should return default value' do
       expect(model.new.name).to be == 'John'
     end
+
+    context 'with optional attribute' do
+      before { model.attribute :profile, :string, optional: true }
+
+      it 'should have getter' do
+        expect(model.new.profile).to eq nil
+        expect(model.new(profile: 'abc').profile).to eq 'abc'
+      end
+    end
   end
 
   describe '#_setter_' do
@@ -124,6 +156,14 @@ describe Acfs::Model::Attributes do
       o.age = '28'
 
       expect(o.age).to be == 28
+    end
+
+    context 'with optional attribute' do
+      before { model.attribute :profile, :string, optional: true }
+
+      it 'should have setter for optional attribute' do
+        expect(model.new.tap{|m| m.profile = 'abc' }.profile).to eq 'abc'
+      end
     end
   end
 
@@ -172,6 +212,14 @@ describe Acfs::Model::Attributes do
 
           resource.updated_at = ''
           expect(resource.updated_at).to eq nil
+        end
+      end
+
+      context 'optional' do
+        it 'should fail with default' do
+          expect do
+            model.send :attribute, :abc, :integer, optional: true, default: 5
+          end.to raise_error ArgumentError, /\AOptional attributes cannot have a default value\.\z/
         end
       end
     end


### PR DESCRIPTION
- Optional attributes will not be included in public attribute listings
  unless set in server response or locally. Therefore they cannot have a
  default value.
