### PR TITLE
Add information to AmbigousStubError

### DIFF
--- a/lib/acfs/errors.rb
+++ b/lib/acfs/errors.rb
@@ -49,7 +49,8 @@ module Acfs
       @stubs     = opts.delete :stubs
       @operation = opts.delete :operation
 
-      super opts, 'Ambiguous stubs.'
+      super opts, "Ambiguous stubs for #{operation.action} on #{operation.resource}.\n" +
+        stubs.map {|s| "  #{s.opts.pretty_inspect}" }.join
     end
   end
 


### PR DESCRIPTION
An error message saying "Ambiguous stubs" doesn't really help to locate the error. With printing out the options it's easier. 