### PR TITLE
add total count for paginated collections

### DIFF
--- a/lib/acfs/collections/paginatable.rb
+++ b/lib/acfs/collections/paginatable.rb
@@ -8,7 +8,7 @@ module Acfs::Collections
         opts[:url]
       end
 
-      attr_reader :total_pages, :current_page
+      attr_reader :total_pages, :current_page, :total_count
     end
 
     def process_response(response)
@@ -47,6 +47,10 @@ module Acfs::Collections
     def setup_headers(headers)
       if headers['X-Total-Pages']
         @total_pages = Integer(headers['X-Total-Pages'])
+      end
+
+      if headers['X-Total-Count']
+        @total_count = Integer(headers['X-Total-Count'])
       end
 
       setup_links headers['Link'] if headers['Link']

--- a/spec/acfs/collection_spec.rb
+++ b/spec/acfs/collection_spec.rb
@@ -13,11 +13,15 @@ describe Acfs::Collection do
       before do
         stub_request(:get, 'http://users.example.org/users')
           .to_return response([{id: 1, name: 'Anon', age: 12, born_at: 'Berlin'}],
-            headers: {'X-Total-Pages' => '2'})
+            headers: {
+              'X-Total-Pages' => '2',
+              'X-Total-Count' => '10'
+            })
       end
 
       its(:total_pages) { should eq 2 }
       its(:current_page) { should eq 1 }
+      its(:total_count) { should eq 10 }
     end
 
     context 'with page parameter' do
@@ -25,11 +29,15 @@ describe Acfs::Collection do
       before do
         stub_request(:get, 'http://users.example.org/users?page=2')
           .to_return response([{id: 1, name: 'Anon', age: 12, born_at: 'Berlin'}],
-            headers: {'X-Total-Pages' => '2'})
+            headers: {
+              'X-Total-Pages' => '2',
+              'X-Total-Count' => '10'
+            })
       end
 
       its(:total_pages) { should eq 2 }
       its(:current_page) { should eq 2 }
+      its(:total_count) { should eq 10 }
     end
 
     context 'with non-numerical page parameter' do
@@ -37,11 +45,15 @@ describe Acfs::Collection do
       before do
         stub_request(:get, 'http://users.example.org/users?page=e546f5')
           .to_return response([{id: 1, name: 'Anon', age: 12, born_at: 'Berlin'}],
-            headers: {'X-Total-Pages' => '2'})
+            headers: {
+              'X-Total-Pages' => '2',
+              'X-Total-Count' => '10'
+            })
       end
 
       its(:total_pages) { should eq 2 }
       its(:current_page) { should eq 'e546f5' }
+      its(:total_count) { should eq 10 }
     end
 
     describe '#next_page' do

--- a/spec/acfs/stub_spec.rb
+++ b/spec/acfs/stub_spec.rb
@@ -163,10 +163,16 @@ describe Acfs::Stub do
         end
 
         let!(:comments) { Comment.all }
-        let(:headers) { {'X-Total-Pages' => '2'} }
+        let(:headers) do
+          {
+            'X-Total-Pages' => '2',
+            'X-Total-Count' => '10'
+          }
+        end
         subject { Acfs.run; comments }
 
         its(:total_pages) { should eq 2 }
+        its(:total_count) { should eq 10 }
       end
     end
 


### PR DESCRIPTION
Paginated responses include a `'X-Total-Pages'` and a `'X-Total-Count'` header field. 
So far only the total pages were passed on in Acfs Collections through `#total_pages`.
This commit adds `#total_count`.


