### PR TITLE
Rework resource types

### DIFF
--- a/lib/acfs/resource/attributes/base.rb
+++ b/lib/acfs/resource/attributes/base.rb
@@ -1,35 +1,27 @@
 module Acfs::Resource::Attributes
   #
   class Base
-    attr_reader :options
+    attr_reader :default
 
-    def initialize(opts = {})
-      @options = opts
-      @options.reverse_merge! allow_nil: true
+    def initialize(default: nil)
+      @default = default
     end
 
-    def nil_allowed?
-      options[:allow_nil]
-    end
-
-    def blank_allowed?
-      options[:allow_blank]
+    def cast(value)
+      cast_value(value) unless value.nil?
     end
 
     def default_value
-      if options[:default].is_a? Proc
-        options[:default]
+      if default.respond_to? :call
+        default
       else
-        cast options[:default]
+        cast default
       end
     end
 
-    def cast(obj)
-      return nil if obj.nil? && nil_allowed? || (obj == '' && blank_allowed?)
-      cast_type obj
-    end
+    private
 
-    def cast_type(_obj)
+    def cast_value(_value)
       raise NotImplementedError
     end
   end

--- a/lib/acfs/resource/attributes/boolean.rb
+++ b/lib/acfs/resource/attributes/boolean.rb
@@ -14,20 +14,17 @@ module Acfs::Resource::Attributes
   #  true, on, yes
   #
   class Boolean < Base
-    TRUE_VALUES = %w(true on yes 1)
+    TRUE_VALUES = [true, 1, '1', 'on', 'yes', 'true']
 
     # @api public
     #
     # Cast given object to boolean.
     #
-    # @param [Object] obj Object to cast.
+    # @param [Object] value Object to cast.
     # @return [TrueClass, FalseClass] Casted boolean.
     #
-    def cast_type(obj)
-      return true if obj.is_a? TrueClass
-      return false if obj.is_a? FalseClass
-
-      TRUE_VALUES.include? obj.to_s
+    def cast_value(value)
+      TRUE_VALUES.include? value
     end
   end
 end

--- a/lib/acfs/resource/attributes/boolean.rb
+++ b/lib/acfs/resource/attributes/boolean.rb
@@ -14,7 +14,7 @@ module Acfs::Resource::Attributes
   #  true, on, yes
   #
   class Boolean < Base
-    TRUE_VALUES = [true, 1, '1', 'on', 'yes', 'true']
+    FALSE_VALUES = [false, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF', 'no', 'NO'].to_set
 
     # @api public
     #
@@ -30,7 +30,7 @@ module Acfs::Resource::Attributes
       if value.blank?
         nil
       else
-        TRUE_VALUES.include? value
+        !FALSE_VALUES.include?(value)
       end
     end
   end

--- a/lib/acfs/resource/attributes/boolean.rb
+++ b/lib/acfs/resource/attributes/boolean.rb
@@ -24,7 +24,14 @@ module Acfs::Resource::Attributes
     # @return [TrueClass, FalseClass] Casted boolean.
     #
     def cast_value(value)
-      TRUE_VALUES.include? value
+      return true if value == true
+      return false if value == false
+
+      if value.blank?
+        nil
+      else
+        TRUE_VALUES.include? value
+      end
     end
   end
 end

--- a/lib/acfs/resource/attributes/date_time.rb
+++ b/lib/acfs/resource/attributes/date_time.rb
@@ -10,22 +10,21 @@ module Acfs::Resource::Attributes
   #   end
   #
   class DateTime < Base
+
     # @api public
     #
     # Cast given object to DateTime.
     #
-    # @param [Object] obj Object to cast.
+    # @param [Object] value Object to cast.
     # @return [DateTime] Casted object as DateTime.
     #
-    def cast_type(obj)
-      if nil_allowed? && obj.blank?
+    def cast_value(value)
+      if value.blank?
         nil
-      elsif obj.is_a? ::DateTime
-        obj
-      elsif obj.is_a?(Time) || obj.is_a?(Date)
-        ::DateTime.iso8601 obj.iso8601
+      elsif value.acts_like?(:time) || value.acts_like?(:date)
+        value.to_datetime
       else
-        ::DateTime.iso8601 obj
+        ::DateTime.iso8601 value
       end
     end
   end

--- a/lib/acfs/resource/attributes/dict.rb
+++ b/lib/acfs/resource/attributes/dict.rb
@@ -14,14 +14,24 @@ module Acfs::Resource::Attributes
     #
     # Cast given object to a dict/hash.
     #
-    # @param [Object] obj Object to cast.
+    # @param [Object] value Object to cast.
     # @return [Hash] Casted object as hash.
     # @raise [TypeError] If object cannot be casted to a hash.
     #
-    def cast_type(obj)
-      return obj if obj.is_a? Hash
-      return obj.to_h if obj.respond_to? :to_h
-      raise TypeError.new "Cannot cast #{obj.inspect} to hash."
+    def cast_value(value)
+      return nil if value.blank?
+
+      if value.is_a?(Hash)
+        value
+      elsif value.respond_to?(:serializable_hash)
+        value.serializable_hash
+      elsif value.respond_to?(:to_hash)
+        value.to_hash
+      elsif value.respond_to?(:to_h)
+        value.to_h
+      else
+        Hash(value)
+      end
     end
   end
 end

--- a/lib/acfs/resource/attributes/float.rb
+++ b/lib/acfs/resource/attributes/float.rb
@@ -13,11 +13,19 @@ module Acfs::Resource::Attributes
     #
     # Cast given object to float.
     #
-    # @param [Object] obj Object to cast.
+    # @param [Object] value Object to cast.
     # @return [Float] Casted object as float.
     #
-    def cast_type(obj)
-      Float obj
+    def cast_value(value)
+      return 0.0 if value.blank?
+
+      case value
+        when ::Float then value
+        when "Infinity" then ::Float::INFINITY
+        when "-Infinity" then -::Float::INFINITY
+        when "NaN" then ::Float::NAN
+        else Float(value)
+      end
     end
   end
 end

--- a/lib/acfs/resource/attributes/integer.rb
+++ b/lib/acfs/resource/attributes/integer.rb
@@ -13,15 +13,15 @@ module Acfs::Resource::Attributes
     #
     # Cast given object to integer.
     #
-    # @param [Object] obj Object to cast.
+    # @param [Object] value Object to cast.
     # @return [Fixnum] Casted object as fixnum.
     #
-    def cast_type(obj)
-      return 0 if obj == ''
-
-      Integer obj
-    rescue ArgumentError => e
-      raise TypeError.new e.message
+    def cast_value(value)
+      if value.blank?
+        0
+      else
+        Integer(value)
+      end
     end
   end
 end

--- a/lib/acfs/resource/attributes/list.rb
+++ b/lib/acfs/resource/attributes/list.rb
@@ -27,7 +27,7 @@ module Acfs::Resource::Attributes
       elsif value.respond_to?(:to_a)
         value.to_a
       else
-        raise TypeError.new "Cannot cast to array: #{value.inspect}"
+        Array(value)
       end
     end
   end

--- a/lib/acfs/resource/attributes/list.rb
+++ b/lib/acfs/resource/attributes/list.rb
@@ -13,13 +13,22 @@ module Acfs::Resource::Attributes
     #
     # Cast given object to a list.
     #
-    # @param [Object] obj Object to cast.
+    # @param [Object] value Object to cast.
     # @return [Fixnum] Casted object as list.
     # @raise [TypeError] If object cannot be casted to a list.
     #
-    def cast_type(obj)
-      return obj.to_a if obj.respond_to? :to_a
-      raise TypeError.new "Cannot cast #{obj.inspect} to array."
+    def cast_value(value)
+      return nil if value.blank?
+
+      if value.is_a?(::Array)
+        value
+      elsif value.respond_to?(:to_ary)
+        value.to_ary
+      elsif value.respond_to?(:to_a)
+        value.to_a
+      else
+        raise TypeError.new "Cannot cast to array: #{value.inspect}"
+      end
     end
   end
 end

--- a/lib/acfs/resource/attributes/string.rb
+++ b/lib/acfs/resource/attributes/string.rb
@@ -14,11 +14,11 @@ module Acfs::Resource::Attributes
     #
     # Cast given object to string.
     #
-    # @param [Object] obj Object to cast.
+    # @param [Object] value Object to cast.
     # @return [String] Casted string.
     #
-    def cast_type(obj)
-      obj.to_s
+    def cast_value(value)
+      value.to_s
     end
   end
 end

--- a/lib/acfs/resource/attributes/uuid.rb
+++ b/lib/acfs/resource/attributes/uuid.rb
@@ -10,7 +10,7 @@ module Acfs::Resource::Attributes
   #
   class UUID < Base
     #
-    REGEXP = /[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}/i
+    UUID_REGEXP = /[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}/i
 
     # @api public
     #
@@ -28,23 +28,16 @@ module Acfs::Resource::Attributes
     #   |     4 | 4      |
     #   |     5 | 12     |
     #
-    # @param [Object] obj Object to cast.
+    # @param [Object] value Object to cast.
     # @return [String] Casted object as UUID.
     #
-    def cast_type(obj)
-      cast_string obj.to_s
-    end
-
-    private
-
-    def cast_string(str)
-      if nil_allowed? && str.blank?
-        return nil
-      elsif str =~ REGEXP
-        str
+    def cast_value(value)
+      if value.blank?
+        nil
+      elsif value.to_s =~ UUID_REGEXP
+        value
       else
-        raise ArgumentError.new "given String `#{str}` " \
-                                'does not look like a UUID'
+        raise TypeError.new "Invalid UUID: `#{value.to_s}'"
       end
     end
   end

--- a/spec/acfs/resource/attributes/boolean_spec.rb
+++ b/spec/acfs/resource/attributes/boolean_spec.rb
@@ -9,11 +9,11 @@ describe Acfs::Resource::Attributes::Boolean do
     end
 
     it 'casts empty string to false' do
-      expect(subject.cast('')).to eq false
+      expect(subject.cast('')).to eq nil
     end
 
     it 'casts blank string to false' do
-      expect(subject.cast("  \t")).to eq false
+      expect(subject.cast("  \t")).to eq nil
     end
 
     it 'preserves boolean values' do
@@ -32,7 +32,6 @@ describe Acfs::Resource::Attributes::Boolean do
     it 'casts any other value to false' do
       expect(subject.cast(0)).to eq false
       expect(subject.cast(2)).to eq false
-      expect(subject.cast('')).to eq false
       expect(subject.cast('wrong')).to eq false
       expect(subject.cast('random')).to eq false
     end

--- a/spec/acfs/resource/attributes/boolean_spec.rb
+++ b/spec/acfs/resource/attributes/boolean_spec.rb
@@ -3,20 +3,35 @@ require 'spec_helper'
 describe Acfs::Resource::Attributes::Boolean do
   subject { Acfs::Resource::Attributes::Boolean.new }
 
-  describe 'cast' do
-    it 'should preserve boolean values' do
+  describe '#cast' do
+    it 'casts nil' do
+      expect(subject.cast(nil)).to eq nil
+    end
+
+    it 'casts empty string to false' do
+      expect(subject.cast('')).to eq false
+    end
+
+    it 'casts blank string to false' do
+      expect(subject.cast("  \t")).to eq false
+    end
+
+    it 'preserves boolean values' do
       expect(subject.cast(false)).to eq false
       expect(subject.cast(true)).to eq true
     end
 
-    it 'should cast TRUE_VALUES to true' do
+    it 'casts TRUE_VALUES to true' do
+      expect(subject.cast(1)).to eq true
       expect(subject.cast('yes')).to eq true
       expect(subject.cast('on')).to eq true
       expect(subject.cast('true')).to eq true
       expect(subject.cast('1')).to eq true
     end
 
-    it 'should cast any other value to false' do
+    it 'casts any other value to false' do
+      expect(subject.cast(0)).to eq false
+      expect(subject.cast(2)).to eq false
       expect(subject.cast('')).to eq false
       expect(subject.cast('wrong')).to eq false
       expect(subject.cast('random')).to eq false

--- a/spec/acfs/resource/attributes/boolean_spec.rb
+++ b/spec/acfs/resource/attributes/boolean_spec.rb
@@ -21,19 +21,36 @@ describe Acfs::Resource::Attributes::Boolean do
       expect(subject.cast(true)).to eq true
     end
 
-    it 'casts TRUE_VALUES to true' do
-      expect(subject.cast(1)).to eq true
-      expect(subject.cast('yes')).to eq true
-      expect(subject.cast('on')).to eq true
-      expect(subject.cast('true')).to eq true
-      expect(subject.cast('1')).to eq true
+    it 'casts falsy values to false' do
+      expect(subject.cast(false)).to eq false
+      expect(subject.cast(0)).to eq false
+      expect(subject.cast('0')).to eq false
+      expect(subject.cast('no')).to eq false
+      expect(subject.cast('NO')).to eq false
+      expect(subject.cast('off')).to eq false
+      expect(subject.cast('OFF')).to eq false
+      expect(subject.cast('false')).to eq false
+      expect(subject.cast('FALSE')).to eq false
+      expect(subject.cast('f')).to eq false
+      expect(subject.cast('F')).to eq false
     end
 
-    it 'casts any other value to false' do
-      expect(subject.cast(0)).to eq false
-      expect(subject.cast(2)).to eq false
-      expect(subject.cast('wrong')).to eq false
-      expect(subject.cast('random')).to eq false
+    it 'casts any other value to true' do
+      expect(subject.cast(true)).to eq true
+      expect(subject.cast(1)).to eq true
+      expect(subject.cast('1')).to eq true
+      expect(subject.cast('yes')).to eq true
+      expect(subject.cast('YES')).to eq true
+      expect(subject.cast('on')).to eq true
+      expect(subject.cast('ON')).to eq true
+      expect(subject.cast('true')).to eq true
+      expect(subject.cast('TRUE')).to eq true
+      expect(subject.cast('t')).to eq true
+      expect(subject.cast('T')).to eq true
+
+      expect(subject.cast(2)).to eq true
+      expect(subject.cast('wrong')).to eq true
+      expect(subject.cast('random')).to eq true
     end
   end
 end

--- a/spec/acfs/resource/attributes/date_time_spec.rb
+++ b/spec/acfs/resource/attributes/date_time_spec.rb
@@ -1,55 +1,49 @@
 require 'spec_helper'
 
 describe Acfs::Resource::Attributes::DateTime do
-  let(:model) { Class.new Acfs::Resource }
-  let(:params) { {} }
-  subject { Acfs::Resource::Attributes::DateTime.new params }
+  let(:type) { Acfs::Resource::Attributes::DateTime.new }
 
-  describe 'cast' do
-    it 'should return same object, if obj is already of DateTime class' do
-      date_time = DateTime.now
-      retval = subject.cast(date_time)
-      expect(retval).to be == date_time
+  describe '#cast' do
+    subject { -> { type.cast value } }
+
+    context 'with nil' do
+      let(:value) { nil }
+      it { expect(subject.call).to eq nil }
     end
 
-    it 'should return parsed object, if obj is of Time class' do
-      time = Time.now
-      retval = subject.cast(time)
-      expect(retval).to be == DateTime.iso8601(time.iso8601)
+    context 'with empty string' do
+      let(:value) { '' }
+      it { expect(subject.call).to eq nil }
     end
 
-    it 'should return parsed object, if obj is of Date class' do
-      date = Date.today
-      retval = subject.cast(date)
-      expect(retval).to be == DateTime.iso8601(date.iso8601)
+    context 'with blank string' do
+      let(:value) { "  \t" }
+      it { expect(subject.call).to eq nil }
     end
 
-    it 'should return parsed object, if obj is of String class in ISO-8601 format' do
-      date_time_string = DateTime.now.iso8601
-      retval = subject.cast(date_time_string)
-      expect(retval).to be == DateTime.iso8601(date_time_string)
+    context 'with DateTime' do
+      let(:value) { DateTime.now }
+      it { expect(subject.call).to eq value }
     end
 
-    it 'should raise an error if obj is of String class not in valid ISO-8601 format' do
-      malformed_string = 'qwe123'
-      expect do
-        subject.cast(malformed_string)
-      end.to raise_error ArgumentError
+    context 'with Time' do
+      let(:value) { Time.now }
+      it { expect(subject.call).to eq value.to_datetime }
     end
 
-    it 'should raise an error if obj is of wrong class (Fixnum)' do
-      fixnum = 12
-      expect do
-        subject.cast(fixnum)
-      end.to raise_error TypeError
+    context 'with Date' do
+      let(:value) { Date.today }
+      it { expect(subject.call).to eq value.to_datetime }
     end
 
-    context 'with allow_nil option' do
-      let(:params) { {allow_nil: true} }
+    context 'with ISO8601' do
+      let(:value) { DateTime.now.iso8601 }
+      it { expect(subject.call.iso8601).to eq value }
+    end
 
-      it 'should accept empty string as nil' do
-        expect(subject.cast('')).to eq nil
-      end
+    context 'with invalid string' do
+      let(:value) { 'qwe123' }
+      it { is_expected.to raise_error ArgumentError }
     end
   end
 end

--- a/spec/acfs/resource/attributes/dict_spec.rb
+++ b/spec/acfs/resource/attributes/dict_spec.rb
@@ -1,50 +1,75 @@
 require 'spec_helper'
 
 describe Acfs::Resource::Attributes::Dict do
-  let(:model) { Class.new(Acfs::Resource) }
-  subject { Acfs::Resource::Attributes::Dict.new }
+  let(:type) { Acfs::Resource::Attributes::Dict.new }
 
-  describe '.cast' do
+  describe '#cast' do
+    subject { -> { type.cast value } }
+
+    context 'with nil' do
+      let(:value) { nil }
+      it { expect(subject.call).to eq nil }
+    end
+
+    context 'with blank string (I)' do
+      let(:value) { '' }
+      it { expect(subject.call).to eq nil }
+    end
+
+    context 'with blank string (II)' do
+      let(:value) { "  \t" }
+      it { expect(subject.call).to eq nil }
+    end
+
     context 'with hash' do
-      let(:sample) { {3 => true, 'asfd' => 4} }
-
-      it 'should return unmodified hash' do
-        expect(subject.cast(sample)).to be sample
-      end
+      let(:value) { {3 => true, abc: 4} }
+      it { expect(subject.call).to eq value }
     end
 
-    context 'with not hashable object' do
-      let(:sample) { Object.new }
-
-      it 'should raise a TypeError' do
-        expect do
-          subject.cast(sample)
-        end.to raise_error TypeError
-      end
+    context 'with non hashable object' do
+      let(:value) { Object.new }
+      it { is_expected.to raise_error TypeError }
     end
 
-    context 'with hashable object' do
-      let(:sample) do
-        o = Object.new
-        class << o
-          def to_h
-            {3 => 4, 'test' => true}
+    context 'with hashable object (I)' do
+      let(:value) do
+        Class.new do
+          def to_hash
+            {id: object_id}
           end
-        end
-        o
+        end.new
       end
 
-      it 'should cast object to hash' do
-        expect(subject.cast(sample)).to eq 3 => 4, 'test' => true
-      end
+      it { expect(subject.call).to eq id: value.object_id }
     end
 
-    context 'with hash subclass' do
-      let(:sample) { HashWithIndifferentAccess.new :test => :foo, 34 => 12 }
-
-      it 'should return obj unmodified' do
-        expect(subject.cast(sample)).to be sample
+    context 'with hashable object (II)' do
+      let(:value) do
+        Class.new do
+          def to_h
+            {id: object_id}
+          end
+        end.new
       end
+
+      it { expect(subject.call).to eq id: value.object_id }
+    end
+
+    context 'with serializable object' do
+      let(:value) do
+        Class.new do
+          def serializable_hash
+            {id: object_id}
+          end
+        end.new
+      end
+
+      it { expect(subject.call).to eq id: value.object_id }
+    end
+
+    context 'with hash subclass object' do
+      let(:value) { HashWithIndifferentAccess.new test: :foo }
+      it { expect(subject.call).to be value }
     end
   end
 end

--- a/spec/acfs/resource/attributes/float_spec.rb
+++ b/spec/acfs/resource/attributes/float_spec.rb
@@ -1,20 +1,59 @@
 require 'spec_helper'
 
 describe Acfs::Resource::Attributes::Float do
-  let(:model) { Class.new Acfs::Resource }
-  subject { described_class.new }
+  let(:type) { Acfs::Resource::Attributes::Float.new }
 
-  describe 'cast' do
-    it 'should return same object, if obj is already of float class' do
-      expect(subject.cast(1.3)).to be == 1.3
+  describe '#cast' do
+    subject { -> { type.cast value } }
+
+    context 'with nil' do
+      let(:value) { nil }
+      it { expect(subject.call).to eq nil }
     end
 
-    it 'should return parsed object, if obj is of Fixnum class' do
-      expect(subject.cast(7)).to be == 7.0
+    context 'with blank string (I)' do
+      let(:value) { '' }
+      it { expect(subject.call).to eq 0.0 }
     end
 
-    it 'should return parsed object, if obj is of String class containing a float' do
-      expect(subject.cast('1.7')).to be == 1.7
+    context 'with blank string (II)' do
+      let(:value) { "  \t" }
+      it { expect(subject.call).to eq 0.0 }
+    end
+
+    context 'with float' do
+      let(:value) { 1.7 }
+      it { expect(subject.call).to eq 1.7 }
+    end
+
+    context 'with Infinity' do
+      let(:value) { 'Infinity' }
+      it { expect(subject.call).to eq ::Float::INFINITY }
+    end
+
+    context 'with -Infinity' do
+      let(:value) { '-Infinity' }
+      it { expect(subject.call).to eq -::Float::INFINITY }
+    end
+
+    context 'with NaN' do
+      let(:value) { 'NaN' }
+      it { expect(subject.call).to be_nan }
+    end
+
+    context 'with fixnum' do
+      let(:value) { 1 }
+      it { expect(subject.call).to eq 1.0 }
+    end
+
+    context 'with valid string' do
+      let(:value) { '1.7' }
+      it { expect(subject.call).to eq 1.7 }
+    end
+
+    context 'with invalid string (I)' do
+      let(:value) { '1.7a' }
+      it { is_expected.to raise_error ArgumentError }
     end
   end
 end

--- a/spec/acfs/resource/attributes/integer_spec.rb
+++ b/spec/acfs/resource/attributes/integer_spec.rb
@@ -1,19 +1,34 @@
 require 'spec_helper'
 
 describe Acfs::Resource::Attributes::Integer do
-  subject { Acfs::Resource::Attributes::Integer.new }
+  let(:type) { Acfs::Resource::Attributes::Integer.new }
 
-  describe 'cast' do
-    it 'should cast integer strings' do
-      expect(subject.cast('123')).to eq 123
+  describe '#cast' do
+    subject { -> { type.cast value } }
+
+    context 'with nil' do
+      let(:value) { nil }
+      it { expect(subject.call).to eq nil }
     end
 
-    it 'should cast empty string (backward compatibility)' do
-      expect(subject.cast('')).to eq 0
+    context 'with empty string' do
+      let(:value) { '' }
+      it { expect(subject.call).to eq 0 }
     end
 
-    it 'should not cast invalid integers' do
-      expect { subject.cast 'abc' }.to raise_error TypeError
+    context 'with blank string' do
+      let(:value) { "  \t" }
+      it { expect(subject.call).to eq 0 }
+    end
+
+    context 'with string' do
+      let(:value) { '123' }
+      it { expect(subject.call).to eq 123 }
+    end
+
+    context 'with invalid string' do
+      let(:value) { '123a' }
+      it { is_expected.to raise_error ArgumentError }
     end
   end
 end

--- a/spec/acfs/resource/attributes/list_spec.rb
+++ b/spec/acfs/resource/attributes/list_spec.rb
@@ -52,7 +52,7 @@ describe Acfs::Resource::Attributes::List do
 
     context 'with non castable object' do
       let(:value) { Object.new }
-      it { is_expected.to raise_error TypeError }
+      it { expect(subject.call).to eq [value] }
     end
   end
 end

--- a/spec/acfs/resource/attributes/list_spec.rb
+++ b/spec/acfs/resource/attributes/list_spec.rb
@@ -1,34 +1,58 @@
 require 'spec_helper'
 
 describe Acfs::Resource::Attributes::List do
-  let(:model) { Class.new Acfs::Resource }
-  subject { described_class.new }
+  let(:type) { Acfs::Resource::Attributes::List.new }
 
-  describe '.cast' do
+  describe '#cast' do
+    subject { -> { type.cast value } }
+
+    context 'with nil' do
+      let(:value) { nil }
+      it { expect(subject.call).to eq nil }
+    end
+
+    context 'with blank string (I)' do
+      let(:value) { '' }
+      it { expect(subject.call).to eq nil }
+    end
+
+    context 'with blank string (II)' do
+      let(:value) { "  \t" }
+      it { expect(subject.call).to eq nil }
+    end
+
     context 'with array' do
-      let(:sample) { %w(abc cde efg) }
-
-      it 'should return unmodified array' do
-        expect(subject.cast(sample)).to be == %w(abc cde efg)
-      end
+      let(:value) { %w(abc cde efg) }
+      it { expect(subject.call).to eq value }
     end
 
-    context 'with not listable object' do
-      let(:sample) { Object.new }
-
-      it 'should raise a TypeError' do
-        expect do
-          subject.cast(sample)
-        end.to raise_error TypeError
+    context 'with convertable object (I)' do
+      let(:value) do
+        Class.new do
+          def to_ary
+            [1, 2, 3]
+          end
+        end.new
       end
+
+      it { expect(subject.call).to eq [1, 2, 3] }
     end
 
-    context 'with listable object' do
-      let(:sample) { 5..10 }
-
-      it 'should cast object to array' do
-        expect(subject.cast(sample)).to be == [5, 6, 7, 8, 9, 10]
+    context 'with convertable object (II)' do
+      let(:value) do
+        Class.new do
+          def to_a
+            [1, 2, 3]
+          end
+        end.new
       end
+
+      it { expect(subject.call).to eq [1, 2, 3] }
+    end
+
+    context 'with non castable object' do
+      let(:value) { Object.new }
+      it { is_expected.to raise_error TypeError }
     end
   end
 end

--- a/spec/acfs/resource/attributes/uuid_spec.rb
+++ b/spec/acfs/resource/attributes/uuid_spec.rb
@@ -1,63 +1,40 @@
 require 'spec_helper'
 
 describe Acfs::Resource::Attributes::UUID do
-  let(:model) { Class.new Acfs::Resource }
-  let(:params) { {} }
-  let(:instance) { described_class.new params }
-  subject { instance }
+  let(:type) { Acfs::Resource::Attributes::UUID.new }
 
-  describe '#cast_type' do
-    let(:param) { '450b7a40-94ad-11e3-baa8-0800200c9a66' }
-    let(:action) { instance.cast param }
-    subject { action }
+  describe '#cast' do
+    subject { -> { type.cast(value) } }
 
-    context 'with String as param' do
-      context 'with valid UUID' do
-        let(:param) { '450b7a40-94ad-11e3-baa8-0800200c9a66' }
-        it { should be_a String }
-        it { should eq param }
-      end
-
-      context 'with invalid UUID' do
-        subject { -> { action } }
-
-        context 'with random non-empty string' do
-          let(:param) { 'invalid string' }
-          it { should raise_error ArgumentError }
-        end
-
-        context 'with UUID string containing invalid characters' do
-          let(:param) { 'xxxxxxxx-yyyy-11e3-baa8-0800200c9a66' }
-          it { should raise_error ArgumentError }
-        end
-
-        context 'with empty string' do
-          let(:param) { '' }
-
-          context 'with allow_nil option' do
-            let(:params) { {allow_nil: true} }
-            subject { action }
-            it { should eq nil }
-          end
-
-          context 'without allow_nil option' do
-            let(:params) { {allow_nil: false} }
-            it { should raise_error ArgumentError }
-          end
-        end
-      end
+    context 'with nil' do
+      let(:value) { nil }
+      it { expect(subject.call).to eq nil }
     end
 
-    context 'with non-String as param' do
-      subject { -> { action } }
+    context 'with empty string' do
+      let(:value) { '' }
+      it { expect(subject.call).to eq nil }
+    end
 
-      invalid_params = {fixnum: 1, float: 3.2, symbol: :invalid, boolean: true}
-      invalid_params.each do |type, incorrect_param|
-        context "with #{type} as param" do
-          let(:param) { incorrect_param }
-          it { should raise_error ArgumentError }
-        end
-      end
+    context 'with blank string' do
+      let(:value) { "  \t" }
+      it { expect(subject.call).to eq nil }
+    end
+
+    context 'with string UUID' do
+      let(:value) { '450b7a40-94ad-11e3-baa8-0800200c9a66' }
+      it { expect(subject.call).to be_a String }
+      it { expect(subject.call).to eq value }
+    end
+
+    context 'with invalid string' do
+      let(:value) { 'invalid string' }
+      it { is_expected.to raise_error TypeError, /invalid UUID/i }
+    end
+
+    context 'with invalid UUID' do
+      let(:value) { 'xxxxxxxx-yyyy-11e3-baa8-0800200c9a66' }
+      it { is_expected.to raise_error TypeError, /invalid UUID/i }
     end
   end
 end

--- a/spec/acfs/resource/attributes_spec.rb
+++ b/spec/acfs/resource/attributes_spec.rb
@@ -162,32 +162,6 @@ describe Acfs::Resource::Attributes do
 
         expect(model.attributes.symbolize_keys).to eq age: 12
       end
-
-      context 'allow nil option' do
-        it 'should allow nil as value' do
-          model.send :attribute, :updated_at, :date_time,
-            default: DateTime.new, allow_nil: true
-
-          resource = model.new
-          expect(resource.updated_at).to eq DateTime.new
-
-          resource.updated_at = ''
-          expect(resource.updated_at).to eq nil
-        end
-      end
-
-      context 'allow blank option' do
-        it 'should allow blank as value' do
-          model.send :attribute, :updated_at, :date_time,
-            default: DateTime.new, allow_blank: true
-
-          resource = model.new
-          expect(resource.updated_at).to eq DateTime.new
-
-          resource.updated_at = ''
-          expect(resource.updated_at).to eq nil
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
* Drop `allow_nil` and `allow_blank`

  `allow_nil` should be replaced by validations and `allow_blank` broke
  much code with less to none use.

* All type handle `nil`, empty and blank strings
  Primitive types cast to false, 0 or 0.0 while other types cast to nil (e.g. DateTime, etc)

Type casting is still strict, casting "123a" to integer will raise an
error and not return 123 like `#to_i`. List and dict types support more
type cohesion methods: `#serializable_hash`, `#to_hash`, `#to_h` on dict
and `#to_ary`, `#to_a` on list.

/cc @mswart @cwillems