### PR TITLE
each_item: Pass collection to provided block

### DIFF
--- a/lib/acfs/resource/query_methods.rb
+++ b/lib/acfs/resource/query_methods.rb
@@ -193,10 +193,13 @@ class Acfs::Resource
       #
       # @yield [item] Callback that will be invoked for each item.
       # @yieldparam item [self] Resource.
+      # @yieldparam collection [Acfs::Collection] Collection.
       #
-      def each_item(opts = {}, &block)
+      def each_item(opts = {})
         each_page(opts) do |collection|
-          collection.each(&block)
+          collection.each do |item|
+            yield item, collection
+          end
         end
       end
 

--- a/spec/acfs/resource/query_methods_spec.rb
+++ b/spec/acfs/resource/query_methods_spec.rb
@@ -528,6 +528,13 @@ describe Acfs::Resource::QueryMethods do
 
           expect(indecies).to eq [1, 2, 3, 4, 5]
         end
+
+        it 'should pass the collection to the provided block' do
+          model.each_item do |_item, collection|
+            expect(collection).to be_a Acfs::Collection
+          end
+          Acfs.run
+        end
       end
     end
   end

--- a/spec/acfs/resource/query_methods_spec.rb
+++ b/spec/acfs/resource/query_methods_spec.rb
@@ -519,14 +519,14 @@ describe Acfs::Resource::QueryMethods do
         end
 
         it 'should iterate all pages' do
-          indecies = []
+          indices = []
           model.each_item do |item|
             expect(item).to be_a MyUser
-            indecies << item.id
+            indices << item.id
           end
           Acfs.run
 
-          expect(indecies).to eq [1, 2, 3, 4, 5]
+          expect(indices).to eq [1, 2, 3, 4, 5]
         end
 
         it 'should pass the collection to the provided block' do


### PR DESCRIPTION
This helps in understanding the current status of pagination
while iterating over the results.

Because of how block arguments are handled in Ruby,
this is also backwards-compatible.