### PR TITLE
Properly encode URI path arguments

### DIFF
--- a/lib/acfs/location.rb
+++ b/lib/acfs/location.rb
@@ -33,7 +33,7 @@ module Acfs
 
     def str
       uri = raw.dup
-      uri.path = URI.escape '/' + struct.map {|s| lookup_arg(s, args) }.join('/')
+      uri.path = '/' + struct.map {|s| lookup_arg(s, args) }.join('/')
       uri.to_s
     end
 
@@ -58,7 +58,7 @@ module Acfs
 
     def lookup_replacement(sym, args)
       value = get_replacement(sym, args).to_s
-      return value unless value.empty?
+      return ::URI.encode_www_form_component(value) unless value.empty?
 
       raise ArgumentError.new "Cannot replace path argument `#{sym}' with empty string."
     end

--- a/spec/acfs/location_spec.rb
+++ b/spec/acfs/location_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe ::Acfs::Location do
+  let(:location) { described_class.new(uri, args) }
+  let(:uri)      { 'http://localhost/users/:id' }
+  let(:args)     { {id: 4} }
+
+  describe '#str' do
+    subject(:str) { location.str }
+
+    it 'replaces variables with values' do
+      expect(str).to eq 'http://localhost/users/4'
+    end
+
+    context 'with special characters' do
+      let(:args) { {id: '4 [@(\/!^$'} }
+
+      it 'escapes special characters' do
+        expect(str).to eq 'http://localhost/users/4+%5B%40%28%5C%2F%21%5E%24'
+      end
+    end
+  end
+end


### PR DESCRIPTION
```
This moves the URI encoding into a URI component encoding inside the
variable lookup. Arguments are now properly encoded when inserted
including special characters.
```