### PR TITLE
Fix Acfs.on callbacks for empty find_by results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,19 @@
 
 
 ## Unreleased
----
 
 ### New
 
 ### Changes
 
 ### Fixes
+* Fix Acfs.on callbacks for empty find_by results (#42)
 
 ### Breaks
 
+---
 
 ## 1.3.1 - (2019-07-02)
----
 
 ### Fixes
 * Improve URL argument encoding when building resource requests


### PR DESCRIPTION
Previously, Acfs.on callbacks would cause an error like this:

    undefined method `loaded?' for nil:Acfs::Util::ResourceDelegator

This happened because `find_by` tried to delegate to a `nil` object,
which can not stand in for a real Acfs resource (which has to
implement `loaded?`).