### PR TITLE
feat: Support for OpenTelemetry tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New
 
+- Experimental support for OpenTelemetry
+
 ### Changes
 
 ### Fixes

--- a/acfs.gemspec
+++ b/acfs.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activemodel', '>= 7.0'
   spec.add_dependency 'activesupport', '>= 7.0'
   spec.add_dependency 'multi_json', '~> 1.0'
+  spec.add_dependency 'opentelemetry-api', '~> 1.0'
+  spec.add_dependency 'opentelemetry-common'
   spec.add_dependency 'rack'
   spec.add_dependency 'typhoeus', '~> 1.0'
 end

--- a/lib/acfs.rb
+++ b/lib/acfs.rb
@@ -7,12 +7,16 @@ require 'active_support/core_ext/string'
 require 'active_support/core_ext/module'
 require 'active_support/notifications'
 
+require 'opentelemetry'
+require 'opentelemetry/common'
+
 module Acfs
   extend ActiveSupport::Autoload
   require 'acfs/version'
   require 'acfs/errors'
   require 'acfs/global'
   require 'acfs/util'
+  require 'acfs/telemetry'
 
   require 'acfs/collection'
   require 'acfs/configuration'

--- a/lib/acfs/global.rb
+++ b/lib/acfs/global.rb
@@ -28,9 +28,11 @@ module Acfs
     # @return [undefined]
     #
     def run
-      ::ActiveSupport::Notifications.instrument 'acfs.before_run'
-      ::ActiveSupport::Notifications.instrument 'acfs.run' do
-        runner.start
+      Telemetry.in_span('acfs.run', attributes: {'code.stacktrace' => caller.join("\n")}) do
+        ::ActiveSupport::Notifications.instrument 'acfs.before_run'
+        ::ActiveSupport::Notifications.instrument 'acfs.run' do
+          runner.start
+        end
       end
     end
 
@@ -50,9 +52,11 @@ module Acfs
     # Reset all queues, stubs and internal state.
     #
     def reset
-      ::ActiveSupport::Notifications.instrument 'acfs.reset' do
-        runner.clear
-        Acfs::Stub.clear
+      Telemetry.in_span('acfs.reset') do
+        ::ActiveSupport::Notifications.instrument 'acfs.reset' do
+          runner.clear
+          Acfs::Stub.clear
+        end
       end
     end
 

--- a/lib/acfs/request.rb
+++ b/lib/acfs/request.rb
@@ -8,17 +8,18 @@ module Acfs
   #
   class Request
     attr_accessor :body, :format
-    attr_reader :url, :headers, :params, :data, :method, :operation
+    attr_reader :uri, :url, :headers, :params, :data, :method, :operation
 
     include Request::Callbacks
     def initialize(url, **options, &block)
-      @url = URI.parse(url.to_s).tap do |_url|
+      @uri = URI.parse(url.to_s).tap do |_url|
         @data    = options.delete(:data) || nil
         @format  = options.delete(:format) || :json
         @headers = options.delete(:headers) || {}
         @params  = options.delete(:params) || {}
         @method  = options.delete(:method) || :get
-      end.to_s
+      end
+      @url = @uri.to_s
 
       @operation = options.delete(:operation) || nil
 

--- a/lib/acfs/telemetry.rb
+++ b/lib/acfs/telemetry.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Acfs
+  module Telemetry
+    class << self
+      delegate :in_span, :start_span, to: :tracer
+
+      def tracer
+        @tracer ||= OpenTelemetry.tracer_provider.tracer('acfs', Acfs::VERSION.to_s)
+      end
+    end
+
+    protected
+
+    def tracer
+      Acfs::Telemetry.tracer
+    end
+  end
+end


### PR DESCRIPTION
This CL adds basic support for OpenTelemetry tracing, with attributes collected similar to what some other instrumentations already collect on ACFS.

For now, OpenTelemetry support is experimental and still needs to be tested in larger applications for a while.